### PR TITLE
Fix case error in finding datasets

### DIFF
--- a/src/schema_api/views.py
+++ b/src/schema_api/views.py
@@ -7,6 +7,7 @@ from rest_framework.decorators import action
 from rest_framework.response import Response
 from schematools.contrib.django.models import Dataset, Profile, Publisher, Scope
 from schematools.exceptions import DatasetTableNotFound, DatasetVersionNotFound
+from schematools.naming import to_snake_case
 from schematools.types import DatasetSchema
 
 import schema_api.openapi.schema as schema
@@ -45,7 +46,7 @@ class DatasetViewSet(viewsets.ReadOnlyModelViewSet):
     @schema.retrieve_datasets_schema
     def retrieve(self, request, name):
         datasets = self.get_queryset()
-        dataset = get_object_or_404(datasets, name=name)
+        dataset = get_object_or_404(datasets, name=to_snake_case(name))
         dataset_schema = dataset.schema
 
         # Table filtering
@@ -67,7 +68,7 @@ class DatasetViewSet(viewsets.ReadOnlyModelViewSet):
     @action(detail=True, url_path=r"(?P<vmajor>v\d{1,3})")
     def version(self, request, name, vmajor):
         datasets = self.get_queryset()
-        dataset = get_object_or_404(datasets, name=name)
+        dataset = get_object_or_404(datasets, name=to_snake_case(name))
         dataset_schema = dataset.schema
 
         # Table filtering
@@ -95,7 +96,7 @@ class DatasetViewSet(viewsets.ReadOnlyModelViewSet):
     @action(detail=True, url_path=r"(?P<vmajor>v\d{1,3})/(?P<table_id>\w+)")
     def table(self, request, name, vmajor, table_id):
         datasets = self.get_queryset()
-        dataset = get_object_or_404(datasets, name=name)
+        dataset = get_object_or_404(datasets, name=to_snake_case(name))
         dataset_schema = dataset.schema
 
         # Scope filtering

--- a/src/tests/conftest.py
+++ b/src/tests/conftest.py
@@ -74,6 +74,13 @@ def gebieden_dataset(here):
 
 
 @pytest.fixture()
+def milieu2025_dataset(here):
+    dataset_path = here / "files/datasets/milieu2025.json"
+    args = [dataset_path]
+    call_command("import_schemas", *args, dry_run=False)
+
+
+@pytest.fixture()
 def scope_fixture(here):
     scope_fp_mdw = here / "files/scopes/fp_mdw.json"
     scope_openbaar = here / "files/scopes/openbaar.json"

--- a/src/tests/files/datasets/milieu2025.json
+++ b/src/tests/files/datasets/milieu2025.json
@@ -1,0 +1,177 @@
+{
+    "type": "dataset",
+    "id": "milieuzones2025",
+    "title": "milieuzones",
+    "description": "Milieuzones die gelden voor verkeer in Amsterdam vanaf 2025",
+    "owner": "Gemeente Amsterdam",
+    "publisher": {
+        "name": "Datateam Mobiliteit",
+        "id": "MOBI",
+        "shortname": "mobili",
+        "tags": {
+            "team": "mobi",
+            "costcenter": "76100005.45219"
+        },
+        "type": "publisher"
+    },
+    "crs": "EPSG:28992",
+    "creator": "Team Uitstootvrije Mobiliteit",
+    "auth": [
+        {
+            "type": "scope",
+            "id": "OPENBAAR",
+            "name": "Openbaar",
+            "accessPackages": {
+                "nonProduction": "EM4W-DATA-schemascope-ot-scope_openbaar",
+                "production": "EM4W-DATA-schemascope-p-scope_openbaar"
+            },
+            "owner": {
+                "$ref": "publishers/DADI"
+            }
+        }
+    ],
+    "authorizationGrantor": "teammobiliteit.data@amsterdam.nl",
+    "defaultVersion": "v1",
+    "versions": {
+        "v1": {
+            "status": "stable",
+            "enableAPI": true,
+            "enableGeosearch": true,
+            "version": "1.1.2",
+            "tables": [
+                {
+                    "id": "vrachtEnBestelauto",
+                    "title": "Gebied met milieuzone vracht- en bestelauto's vanaf 01/01/2025",
+                    "type": "table",
+                    "version": "1.1.2",
+                    "status": "stable",
+                    "schema": {
+                        "$schema": "http://json-schema.org/draft-07/schema#",
+                        "identifier": "id",
+                        "type": "object",
+                        "additionalProperties": false,
+                        "required": [
+                            "id",
+                            "schema"
+                        ],
+                        "display": "id",
+                        "properties": {
+                            "schema": {
+                                "$ref": "https://schemas.data.amsterdam.nl/schema@v4.0.0#/definitions/schema"
+                            },
+                            "id": {
+                                "type": "integer",
+                                "title": "Vracht en bestelauto milieuzone ID",
+                                "description": "Unieke aanduiding van het milieuzone gebied."
+                            },
+                            "geometry": {
+                                "title": "Vracht en bestelauto milieuzone geometrie",
+                                "$ref": "https://geojson.org/schema/MultiPolygon.json",
+                                "description": "Aanduiding voor de geometrie van het beheerobject volgens het Stelsel van de Rijksdriehoeksmeting (RD, epsg:28992)."
+                            }
+                        }
+                    }
+                },
+                {
+                    "id": "personenauto",
+                    "title": "Gebied met milieuzone personenauto's vanaf 01/01/2025",
+                    "type": "table",
+                    "version": "1.1.2",
+                    "status": "stable",
+                    "schema": {
+                        "$schema": "http://json-schema.org/draft-07/schema#",
+                        "identifier": "id",
+                        "type": "object",
+                        "additionalProperties": false,
+                        "required": [
+                            "id",
+                            "schema"
+                        ],
+                        "display": "id",
+                        "properties": {
+                            "schema": {
+                                "$ref": "https://schemas.data.amsterdam.nl/schema@v4.0.0#/definitions/schema"
+                            },
+                            "id": {
+                                "type": "integer",
+                                "title": "Personenauto milieuzone ID",
+                                "description": "Unieke aanduiding van het milieuzone gebied voor personenauto's."
+                            },
+                            "geometry": {
+                                "title": "Personenauto milieuzone geometrie",
+                                "$ref": "https://geojson.org/schema/MultiPolygon.json",
+                                "description": "Aanduiding voor de geometrie van het beheerobject volgens het Stelsel van de Rijksdriehoeksmeting (RD, epsg:28992)."
+                            }
+                        }
+                    }
+                },
+                {
+                    "id": "touringcar",
+                    "title": "Gebied met milieuzone touringcars vanaf 01/01/2025",
+                    "type": "table",
+                    "version": "1.1.2",
+                    "status": "stable",
+                    "schema": {
+                        "$schema": "http://json-schema.org/draft-07/schema#",
+                        "identifier": "id",
+                        "type": "object",
+                        "additionalProperties": false,
+                        "required": [
+                            "id",
+                            "schema"
+                        ],
+                        "display": "id",
+                        "properties": {
+                            "schema": {
+                                "$ref": "https://schemas.data.amsterdam.nl/schema@v4.0.0#/definitions/schema"
+                            },
+                            "id": {
+                                "type": "integer",
+                                "title": "Touringcar milieuzone ID",
+                                "description": "Unieke aanduiding van het milieuzone gebied voor touringcars."
+                            },
+                            "geometry": {
+                                "title": "Touringcar milieuzone geometrie",
+                                "$ref": "https://geojson.org/schema/MultiPolygon.json",
+                                "description": "Aanduiding voor de geometrie van het beheerobject volgens het Stelsel van de Rijksdriehoeksmeting (RD, epsg:28992)."
+                            }
+                        }
+                    }
+                },
+                {
+                    "id": "taxi",
+                    "title": "Gebied met milieuzone taxi's vanaf 01/01/2025",
+                    "type": "table",
+                    "version": "1.1.2",
+                    "status": "stable",
+                    "schema": {
+                        "$schema": "http://json-schema.org/draft-07/schema#",
+                        "identifier": "id",
+                        "type": "object",
+                        "additionalProperties": false,
+                        "required": [
+                            "id",
+                            "schema"
+                        ],
+                        "display": "id",
+                        "properties": {
+                            "schema": {
+                                "$ref": "https://schemas.data.amsterdam.nl/schema@v4.0.0#/definitions/schema"
+                            },
+                            "id": {
+                                "type": "integer",
+                                "title": "Taxi milieuzone ID",
+                                "description": "Unieke aanduiding van het milieuzone gebied voor taxi's."
+                            },
+                            "geometry": {
+                                "title": "Taxi milieuzone geometrie",
+                                "$ref": "https://geojson.org/schema/MultiPolygon.json",
+                                "description": "Aanduiding voor de geometrie van het beheerobject volgens het Stelsel van de Rijksdriehoeksmeting (RD, epsg:28992)."
+                            }
+                        }
+                    }
+                }
+            ]
+        }
+    }
+}

--- a/src/tests/test_views.py
+++ b/src/tests/test_views.py
@@ -29,6 +29,14 @@ class TestDatasetViews:
         assert response.status_code == 200
         assert response.data["id"] == "bomen"
 
+    def test_dataset_detail_snake_case(self, client, milieu2025_dataset):
+        """Ensure CamelCase dataset id is found (dataset id is snake_case in db)"""
+        response = client.get(
+            reverse("dataset-detail", kwargs={"name": "milieuzones2025"}),
+        )
+        assert response.status_code == 200
+        assert response.data["id"] == "milieuzones2025"
+
     def test_dataset_detail_filter_on_tables(self, client, gebieden_dataset):
         response = client.get(
             reverse(


### PR DESCRIPTION
https://api.schemas.data.amsterdam.nl/v1/datasets/brk2 <- 404
https://api.schemas.data.amsterdam.nl/v1/datasets/brk_2 <- gaat wel goed

Brk2 dataset kan niet worden gevonden, komt deze error dus doordat de datasets id's in de database in snake case moeten zijn? Want de id's in de DatasetSchema's zijn wel in camelcase.

Is dit dan genoeg als fix? En moet er een testje bij? Bij de tests gebruik ik fixtures voor de DatasetSchema's en komt er geen database aan te pas, dus ik kan deze bug niet echt nabootsen op deze manier